### PR TITLE
Fix code sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ SESSION_REDIS_PORT = 6379
 SESSION_REDIS_DB = 0
 SESSION_REDIS_PASSWORD = 'password'
 SESSION_REDIS_PREFIX = 'session'
-SESSION_REDIS_SOCKET_TIMEOUT=1
+SESSION_REDIS_SOCKET_TIMEOUT = 1
 
 # If you prefer domain socket connection, 
 # you can just add this line instead of SESSION_REDIS_HOST and SESSION_REDIS_PORT.


### PR DESCRIPTION
According to PEP8 should have spaces around the assignment operator.
